### PR TITLE
fix(messaging): Fixup client API

### DIFF
--- a/src/client/client_api/commands.rs
+++ b/src/client/client_api/commands.rs
@@ -8,7 +8,7 @@
 
 use super::Client;
 use crate::client::Error;
-use crate::messaging::client::{ClientSig, Cmd};
+use crate::messaging::{client::Cmd, ClientSigned};
 use crate::types::{PublicKey, Signature};
 use log::debug;
 use std::net::SocketAddr;
@@ -23,7 +23,7 @@ impl Client {
         target: Option<SocketAddr>,
     ) -> Result<(), Error> {
         debug!("Sending Cmd: {:?}", cmd);
-        let client_sig = ClientSig {
+        let client_sig = ClientSigned {
             public_key: client_pk,
             signature,
         };

--- a/src/client/client_api/queries.rs
+++ b/src/client/client_api/queries.rs
@@ -8,7 +8,7 @@
 
 use super::Client;
 use crate::client::{connections::QueryResult, errors::Error};
-use crate::messaging::client::{ClientSig, Query};
+use crate::messaging::{client::Query, ClientSigned};
 use crate::types::{PublicKey, Signature};
 use log::debug;
 
@@ -21,7 +21,7 @@ impl Client {
         signature: Signature,
     ) -> Result<QueryResult, Error> {
         debug!("Sending Query: {:?}", query);
-        let client_sig = ClientSig {
+        let client_sig = ClientSigned {
             public_key: client_pk,
             signature,
         };

--- a/src/client/client_api/transfers/mod.rs
+++ b/src/client/client_api/transfers/mod.rs
@@ -14,8 +14,9 @@ mod simulated_payouts;
 mod write_apis;
 
 use crate::client::{Client, Error};
-use crate::messaging::client::{
-    ClientSig, Cmd, DataCmd, Query, QueryResponse, TransferCmd, TransferQuery,
+use crate::messaging::{
+    client::{Cmd, DataCmd, Query, QueryResponse, TransferCmd, TransferQuery},
+    ClientSigned,
 };
 use crate::transfers::{ActorEvent, TransferInitiated};
 use crate::types::{
@@ -249,7 +250,7 @@ impl Client {
 
         let client_pk = self.public_key();
         let signature = self.keypair.sign(b"TODO");
-        let client_sig = ClientSig {
+        let client_sig = ClientSigned {
             public_key: client_pk,
             signature,
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,11 +62,11 @@
 #[macro_use]
 extern crate tracing;
 
-//pub mod client;
+pub mod client;
 /// The messaging interface to the network. Messages sent and serialised in line with this module should be acted upon by the network.
 pub mod messaging;
 //pub mod node;
-pub mod routing;
-//pub mod transfers;
+// pub mod routing;
+pub mod transfers;
 pub mod types;
 //pub mod url;


### PR DESCRIPTION
- 9ba360a14 **fix(client): Restore client mod and get it compiling**

  Whilst it compiles, the implementation is not finished. Current issues
  include:
  
  1. Verbose and duplicated serialisation logic in `Session`.
  2. Still requires duplicate serialisation to succeed (once to generate
     signature of serialised message, once again to serialise message
     before sending).
  3. Impossible to generate a signature over the whole message, since
     message ID is generated by send function and stored in message.
  
  Issues 2 & 3 are pre-existing, but are technically avoided since we
  don't generate real signatures (we just sign `b"TODO"`). Issue 1 could
  easily be fixed with a helper `fn`, but this would likely need to be
  broken up again when it comes time to actually implement signatures, so
  it's been left as-is for now.
