### PR TITLE
fix: make retry wait for a reasonable portion of querytimeout

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ default-features = false
 features = ["archive-tar", "archive-zip", "compression-flate2", "compression-zip-deflate", "rustls"]
 
 [dependencies.tokio]
-version = "1.8.0"
+version = "1.12.0"
 features = ["fs", "io-util", "macros", "rt", "rt-multi-thread", "sync"]
 
 [dev-dependencies]

--- a/src/client/client_api/blob_apis.rs
+++ b/src/client/client_api/blob_apis.rs
@@ -276,7 +276,6 @@ mod tests {
 
     use super::Spot;
 
-    const BLOB_TEST_QUERY_TIMEOUT: u64 = 60;
     const MIN_BLOB_SIZE: usize = self_encryption::MIN_ENCRYPTABLE_BYTES;
     const DELAY_DIVIDER: usize = 500_000;
 
@@ -306,7 +305,7 @@ mod tests {
     // Test storing and reading min size blob.
     #[tokio::test(flavor = "multi_thread")]
     async fn store_and_read_3kb() -> Result<()> {
-        let client = create_test_client(Some(BLOB_TEST_QUERY_TIMEOUT)).await?;
+        let client = create_test_client(None).await?;
 
         let blob = Blob::new(random_bytes(MIN_BLOB_SIZE))?;
 
@@ -414,7 +413,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     #[ignore = "too heavy for CI"]
     async fn parallel_timings() -> Result<()> {
-        let client = create_test_client(Some(BLOB_TEST_QUERY_TIMEOUT)).await?;
+        let client = create_test_client(None).await?;
 
         let handles = (0..1000_usize)
             .map(|i| (i, client.clone()))
@@ -446,7 +445,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     #[ignore = "too heavy for CI"]
     async fn one_by_one_timings() -> Result<()> {
-        let client = create_test_client(Some(BLOB_TEST_QUERY_TIMEOUT)).await?;
+        let client = create_test_client(None).await?;
 
         for i in 0..1000_usize {
             let blob = Blob::new(random_bytes(MIN_BLOB_SIZE))?;
@@ -461,7 +460,7 @@ mod tests {
 
     async fn store_and_read_blob(size: usize, scope: Scope) -> Result<()> {
         let blob = Blob::new(random_bytes(size))?;
-        let client = create_test_client(Some(BLOB_TEST_QUERY_TIMEOUT)).await?;
+        let client = create_test_client(None).await?;
         let address = client.write_blob_to_network(blob.clone(), scope).await?;
 
         // the larger the file, the longer we have to wait before we start querying
@@ -478,7 +477,7 @@ mod tests {
 
     async fn store_and_read_spot(size: usize, scope: Scope) -> Result<()> {
         let spot = Spot::new(random_bytes(size))?;
-        let client = create_test_client(Some(BLOB_TEST_QUERY_TIMEOUT)).await?;
+        let client = create_test_client(None).await?;
         let address = client.write_spot_to_network(spot.clone(), scope).await?;
 
         // the larger the size, the longer we have to wait before we start querying
@@ -495,7 +494,7 @@ mod tests {
     }
 
     async fn seek_for_test(blob: Blob, pos: usize, len: usize) -> Result<Bytes> {
-        let client = create_test_client(Some(BLOB_TEST_QUERY_TIMEOUT)).await?;
+        let client = create_test_client(None).await?;
         let address = client
             .write_blob_to_network(blob.clone(), Scope::Public)
             .await?;

--- a/src/client/client_api/queries.rs
+++ b/src/client/client_api/queries.rs
@@ -27,10 +27,25 @@ impl Client {
         let serialised_query = WireMsg::serialize_msg_payload(&msg)?;
         let signature = self.keypair.sign(&serialised_query);
 
+        // we divide the total query timeout by this to get a more reasonable starting timeout
+        // this also represents the max retries possible _if no backoff were present_, while still staying within the max_timeout
+        // in practice it's _probably_ one less than this value
+        let max_retry_count = 11.0;
+
+        let starting_query_timeout = self.query_timeout.div_f32(max_retry_count);
+        trace!(
+            "Setting up query retry, initial interval is: {:?}",
+            starting_query_timeout
+        );
         retry(
             || async {
-                tokio::time::timeout(
-                    self.query_timeout,
+                debug!(
+                    "Attempting {:?} with a query timeout of {:?}",
+                    query, starting_query_timeout
+                );
+                let res = tokio::time::timeout(
+                    // The max timeout is total_timeout / retry_factor, so we should get at least lowest_bound_count retries within the total time (if needed)
+                    starting_query_timeout,
                     self.send_signed_query(
                         query.clone(),
                         client_pk,
@@ -38,13 +53,19 @@ impl Client {
                         signature.clone(),
                     ),
                 )
-                .await
-                .map_err(backoff::Error::Transient)
+                .await;
+
+                debug!("Query {:?} result (w/ timeout) was: {:?}", query, res);
+                res.map_err(backoff::Error::Transient)
             },
-            self.query_timeout.mul_f32(3.0),
+            starting_query_timeout,
+            self.query_timeout,
         )
         .await
-        .map_err(|_| Error::NoResponse)?
+        .map_err(|_| {
+            debug!("retries all failed for {:?}, returning no response", query);
+            Error::NoResponse
+        })?
     }
 
     /// Send a Query to the network and await a response

--- a/src/client/connections/messaging.rs
+++ b/src/client/connections/messaging.rs
@@ -227,7 +227,7 @@ impl Session {
         let msg_id = MessageId::new();
 
         debug!(
-            "Sending query message {:?}, msg_id: {}, from {}, to the {} Elders closest to data name: {:?}",
+            "Sending query message {:?}, msg_id: {:?}, from {}, to the {} Elders closest to data name: {:?}",
             query,
             msg_id,
             endpoint.public_addr(),
@@ -437,6 +437,7 @@ pub(crate) async fn send_message(
     let mut failures = 0;
     results.iter().for_each(|res| {
         if res.is_err() {
+            error!("Client error contacting node was: {:?}", res);
             failures += 1;
         }
     });

--- a/src/client/connections/mod.rs
+++ b/src/client/connections/mod.rs
@@ -25,6 +25,7 @@ type QueryResponseSender = Sender<QueryResponse>;
 type PendingQueryResponses = Arc<RwLock<HashMap<OperationId, QueryResponseSender>>>;
 use uluru::LRUCache;
 
+#[derive(Debug)]
 pub(crate) struct QueryResult {
     pub(super) response: QueryResponse,
     // TODO: unify this

--- a/src/client/utils/mod.rs
+++ b/src/client/utils/mod.rs
@@ -20,6 +20,7 @@ use std::time::Duration;
 
 pub(crate) fn retry<R, E, Fn, Fut>(
     op: Fn,
+    initial_interval: Duration,
     max_elapsed_time: Duration,
 ) -> impl Future<Output = Result<R, E>>
 where
@@ -27,8 +28,8 @@ where
     Fut: Future<Output = Result<R, backoff::Error<E>>>,
 {
     let backoff = ExponentialBackoff {
-        initial_interval: Duration::from_millis(500),
-        max_interval: Duration::from_secs(15),
+        initial_interval,
+        max_interval: max_elapsed_time,
         max_elapsed_time: Some(max_elapsed_time),
         ..Default::default()
     };

--- a/src/client/utils/test_utils/mod.rs
+++ b/src/client/utils/test_utils/mod.rs
@@ -33,6 +33,7 @@ where
     tokio::time::sleep(tokio::time::Duration::from_secs(delay as u64)).await;
     let res = retry(
         || async { Ok(f().await?) },
+        tokio::time::Duration::from_secs(5),
         tokio::time::Duration::from_secs(180),
     )
     .await;


### PR DESCRIPTION
I would say this is more inline with what we expect from `max_query_timeout`.

Here i essentially divide this to get a rough number of retries possible in that time, and use that as the base timeout.